### PR TITLE
log output to a callback function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# VS Code
+.vscode/*

--- a/log/log.go
+++ b/log/log.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Celer Network
+// Copyright 2018-2020 Celer Network
 
 // API:
 // Trace[f|ln], Debug[f|ln], Info[f|ln], Warn[f|ln], Error[f|ln], Fatal[f|ln], Panic[f|ln],

--- a/log/log.go
+++ b/log/log.go
@@ -90,6 +90,10 @@ var levelInfo = []levelmeta{
 
 type arrayFlags []string
 
+type Output interface {
+	OnLog(output string)
+}
+
 // Logger obejct
 type Logger struct {
 	file       *os.File     // log file writer
@@ -106,6 +110,7 @@ type Logger struct {
 	localtime  bool         // use local time
 	longfile   bool         // show long file path
 	pathsplit  string       // file path splitter
+	out        Output       // output to a callback function
 	rw         sync.RWMutex // protect config values
 }
 
@@ -232,6 +237,8 @@ func (l *Logger) output(msg string, level Level) {
 			}
 		}
 		l.file.Write(buf.Bytes())
+	} else if l.out != nil {
+		l.out.OnLog(buf.String())
 	} else {
 		os.Stderr.Write(buf.Bytes())
 	}
@@ -327,6 +334,12 @@ func SetFileName(name string) {
 	std.rw.Lock()
 	defer std.rw.Unlock()
 	std.name = name
+}
+
+func SetOutput(out Output) {
+	std.rw.Lock()
+	defer std.rw.Unlock()
+	std.out = out
 }
 
 func SetPrefix(prefix string) {

--- a/log/log.go
+++ b/log/log.go
@@ -91,15 +91,18 @@ var levelInfo = []levelmeta{
 type arrayFlags []string
 
 type Output interface {
-	OnLog(output string)
+	// Write writes len(b) bytes to the File.
+	// It returns the number of bytes written and an error, if any.
+	Write(output []byte) (n int, err error)
 }
 
 // Logger obejct
 type Logger struct {
+	out        Output       // log default writer
 	file       *os.File     // log file writer
 	filetime   time.Time    // file created time
 	mu         sync.Mutex   // protect log writer
-	dir        string       // write log into directory instead of stderr
+	dir        string       // write log into files in the directory instead of the default writer
 	name       string       // log file name
 	prefix     string       // log entry prefix
 	level      Level        // log level
@@ -110,7 +113,6 @@ type Logger struct {
 	localtime  bool         // use local time
 	longfile   bool         // show long file path
 	pathsplit  string       // file path splitter
-	out        Output       // output to a callback function
 	rw         sync.RWMutex // protect config values
 }
 
@@ -134,6 +136,7 @@ func init() {
 	bufferPool = &sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}
 	std.level = InfoLevel
 	std.filetime = time.Time{}
+	std.out = os.Stderr
 }
 
 var onceLogFile sync.Once
@@ -220,32 +223,30 @@ func (l *Logger) output(msg string, level Level) {
 		onceLogFile.Do(func() { // create folder and first log file
 			err := os.MkdirAll(l.dir, 0755)
 			if err != nil {
-				os.Stderr.Write(buf.Bytes())
+				l.out.Write(buf.Bytes())
 				l.exit(err)
 			}
 			err = l.createFile(t)
 			if err != nil {
-				os.Stderr.Write(buf.Bytes())
+				l.out.Write(buf.Bytes())
 				l.exit(err)
 			}
 		})
 		if l.rotate && t.Day() != l.filetime.Day() {
 			err := l.rotateFile(t)
 			if err != nil {
-				os.Stderr.Write(buf.Bytes())
+				l.out.Write(buf.Bytes())
 				l.exit(err)
 			}
 		}
 		l.file.Write(buf.Bytes())
-	} else if l.out != nil {
-		l.out.OnLog(buf.String())
 	} else {
-		os.Stderr.Write(buf.Bytes())
+		l.out.Write(buf.Bytes())
 	}
 }
 
 func (l *Logger) exit(err error) {
-	fmt.Fprintf(os.Stderr, "FATAL: log exiting because of error: %w\n", err)
+	fmt.Fprintf(l.out, "FATAL: log exiting because of error: %w\n", err)
 	os.Exit(2)
 }
 
@@ -289,7 +290,7 @@ func (l *Logger) createFile(t time.Time) error {
 	l.file, err = os.Create(fname)
 	if err == nil {
 		logpath, _ := filepath.Abs(fname)
-		os.Stderr.Write([]byte("Log to " + logpath + "\n"))
+		l.out.Write([]byte("Log to " + logpath + "\n"))
 		l.filetime = t
 		return nil
 	}
@@ -315,7 +316,7 @@ func SetLevel(level Level) {
 func SetLevelByName(name string) {
 	level, valid := getLevelByName(name)
 	if !valid {
-		os.Stderr.Write([]byte("Error: invalid log level flag, use default InfoLevel\n"))
+		std.out.Write([]byte("Error: invalid log level flag, use default InfoLevel\n"))
 	}
 	SetLevel(level)
 }
@@ -509,7 +510,7 @@ func (l *Level) Set(value string) error {
 	if valid {
 		levelSetByFlag = true
 	} else {
-		os.Stderr.Write([]byte("Error: invalid log level flag, use default InfoLevel\n"))
+		std.out.Write([]byte("Error: invalid log level flag, use default InfoLevel\n"))
 	}
 	SetLevel(level)
 	return nil

--- a/log/test/logtest.go
+++ b/log/test/logtest.go
@@ -1,19 +1,33 @@
 // Copyright 2018-2019 Celer Network
 
 // Try run with different flags. Example:
-// go run clog/test/clogtest.go -logcolor -loglevel=debug
-// go run clog/test/clogtest.go -loglevel=warn -loglocaltime -loglongfile
+// go run logtest.go -logcolor -loglevel=debug
+// go run logtest.go -loglevel=warn -loglocaltime -loglongfile
+// go run logtest.go -testoutput
 
 package main
 
 import (
 	"flag"
+	"fmt"
 
 	"github.com/celer-network/goutils/log"
 )
 
+type TestOutput struct {
+}
+
+func (cb TestOutput) OnLog(output string) {
+	fmt.Printf("receive log output: %s", output)
+}
+
+var testoutput = flag.Bool("testoutput", false, "test log output callback")
+
 func main() {
 	flag.Parse()
+	if *testoutput {
+		log.SetOutput(TestOutput{})
+	}
 	log.Trace("trace every step")
 	log.Debug("looking into what's really happening")
 	log.Infof("x is set to %d", 2)

--- a/log/test/logtest.go
+++ b/log/test/logtest.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2019 Celer Network
+// Copyright 2018-2020 Celer Network
 
 // Try run with different flags. Example:
 // go run logtest.go -logcolor -loglevel=debug

--- a/log/test/logtest.go
+++ b/log/test/logtest.go
@@ -17,8 +17,9 @@ import (
 type TestOutput struct {
 }
 
-func (cb TestOutput) OnLog(output string) {
+func (cb TestOutput) Write(output []byte) (n int, err error) {
 	fmt.Printf("receive log output: %s", output)
+	return len(output), nil
 }
 
 var testoutput = flag.Bool("testoutput", false, "test log output callback")


### PR DESCRIPTION
Enable the mobile client to receive log output. See `log/test/logtest.go` for example usage.