### PR TITLE
Limit SQLite to a single open connection.

### DIFF
--- a/sqldb/sqldb.go
+++ b/sqldb/sqldb.go
@@ -82,6 +82,11 @@ func NewDb(driver, info string, poolSize int) (*Db, error) {
 			db.SetMaxIdleConns(poolSize)
 			db.SetMaxOpenConns(poolSize)
 		}
+	} else if driver == "sqlite3" {
+		// Force a single connection to serialize all SQLite operations and avoid
+		// the "database is locked" errors due to the lack of concurrent writes.
+		// As a downside, the read operations are also serialized.
+		db.SetMaxOpenConns(1)
 	}
 
 	d := &Db{

--- a/sqldb/sqldb_test.go
+++ b/sqldb/sqldb_test.go
@@ -571,6 +571,8 @@ func TestTransactionConflict_crdb(t *testing.T) {
 	runWithDatabase(t, false, testTransactionConflict)
 }
 
-func TestTransactionConflict_sqlite(t *testing.T) {
-	runWithDatabase(t, true, testTransactionConflict)
-}
+// With a single SQLite connection configured, this test deadlocks because
+// it is designed to force the need of concurrent progress on 2 transactions.
+//func TestTransactionConflict_sqlite(t *testing.T) {
+//	runWithDatabase(t, true, testTransactionConflict)
+//}


### PR DESCRIPTION
This avoids the "database is locked" errors that happen in cases of
concurrent writes.  It forces all operations to be serialized on a
single connection.