### PR TITLE
Add NewKafRecvFromLatest to create a kafka receiver from latest/new msg

### DIFF
--- a/kaf/kaf.go
+++ b/kaf/kaf.go
@@ -84,6 +84,19 @@ func NewKafRecv(kafkaUrl, component, topic string, cb KafRecvFunc) *KafRecv {
 	return makeKafRecv(kafkaUrl, component, topic, cb, mkReader)
 }
 
+// Create a KafRecv and receive from LATEST/new messages.
+// This is different from NewKafRecv which receives from beginning of msgs
+func NewKafRecvFromLatest(kafkaUrl, component, topic string, cb KafRecvFunc) *KafRecv {
+	// Constructor of real internal Kafka readers.
+	mkReader := func(config *kafka.ReaderConfig) KafReader {
+		// default StartOffset is FirstOffset
+		config.StartOffset = kafka.LastOffset
+		return kafka.NewReader(*config)
+	}
+
+	return makeKafRecv(kafkaUrl, component, topic, cb, mkReader)
+}
+
 // Internal helper to create a KafRecv with a specified constructor of a Kafka reader.
 // It allows unittests to be written passing it a constructor of mock Kafka readers.
 func makeKafRecv(kafkaUrl, component, topic string, cb KafRecvFunc, mkReader KafReaderFunc) *KafRecv {
@@ -91,12 +104,11 @@ func makeKafRecv(kafkaUrl, component, topic string, cb KafRecvFunc, mkReader Kaf
 	topic = strings.ToLower(topic)
 
 	config := &kafka.ReaderConfig{
-		Brokers:     strings.Split(kafkaUrl, ","),
-		Topic:       topic,
-		GroupID:     component + "-" + topic,
-		MinBytes:    100,  // 100 bytes
-		MaxBytes:    10e6, // 10MB
-		StartOffset: kafka.LastOffset,
+		Brokers:  strings.Split(kafkaUrl, ","),
+		Topic:    topic,
+		GroupID:  component + "-" + topic,
+		MinBytes: 100,  // 100 bytes
+		MaxBytes: 10e6, // 10MB
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/kaf/kaf.go
+++ b/kaf/kaf.go
@@ -91,11 +91,12 @@ func makeKafRecv(kafkaUrl, component, topic string, cb KafRecvFunc, mkReader Kaf
 	topic = strings.ToLower(topic)
 
 	config := &kafka.ReaderConfig{
-		Brokers:  strings.Split(kafkaUrl, ","),
-		Topic:    topic,
-		GroupID:  component + "-" + topic,
-		MinBytes: 100,  // 100 bytes
-		MaxBytes: 10e6, // 10MB
+		Brokers:     strings.Split(kafkaUrl, ","),
+		Topic:       topic,
+		GroupID:     component + "-" + topic,
+		MinBytes:    100,  // 100 bytes
+		MaxBytes:    10e6, // 10MB
+		StartOffset: kafka.LastOffset,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
If it's a first time ever reader (ie. kafka hasn't seen the consumer group before), the new api creates readerlast/new msgs (kafka.LastOffset)

The caveat of this new reader is in case kafka reset the committed offset (default 7 days) due to timeout, start again won't catch missed msgs. restart of consumer won't be affected as the committed offset is saved in kafka.

in above case, read from first behavior needs to process possibly duplicated msgs.