### PR TITLE
Set context timeout to 10 seconds in transactor

### DIFF
--- a/eth/transactor.go
+++ b/eth/transactor.go
@@ -29,7 +29,7 @@ var (
 	ErrExceedMaxGas        = errors.New("suggested gas price exceeds max allowed")
 	ErrConflictingGasFlags = errors.New("cannot specify both legacy and EIP-1559 gas flags")
 
-	ctxTimeout = 3 * time.Second
+	ctxTimeout = 10 * time.Second
 )
 
 type Transactor struct {


### PR DESCRIPTION
Allow slower estimateGas calls.